### PR TITLE
fix: resolve errors when updating username

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/rn/RNAPI.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/rn/RNAPI.kt
@@ -21,6 +21,7 @@ class RNAPI : Plugin(Manifest("RNAPI")) {
         patchUser()
         patchUserProfile()
         patchDefaultAvatars()
+        patchUsername()
     }
 
     override fun start(context: Context?) {}


### PR DESCRIPTION
Removed the validation for discriminator, and also hide's the discriminator input entirely if the user has already been moved to the new username system.